### PR TITLE
Pretend I meant to write FencedIn that way

### DIFF
--- a/WhosAGoodBoy/Who's A Good Boy/Assets/Scenes/SampleScene.unity
+++ b/WhosAGoodBoy/Who's A Good Boy/Assets/Scenes/SampleScene.unity
@@ -361,7 +361,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Fence:
     m_Center: {x: 1.5, y: 2, z: 0}
-    m_Extent: {x: 9, y: 9, z: 0}
+    m_Extent: {x: 9, y: 9, z: 10}
   FencedBound:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0.1, y: 0.1, z: 0}

--- a/WhosAGoodBoy/Who's A Good Boy/Assets/Scripts/Editor/EditModeTests/BoundExtensionsTest.cs
+++ b/WhosAGoodBoy/Who's A Good Boy/Assets/Scripts/Editor/EditModeTests/BoundExtensionsTest.cs
@@ -99,4 +99,28 @@ public class BoundExtensionsTest {
         Assert.AreEqual(new Vector3(-3, 0, 0), inner.Delta(outer));
     }
 
+    [Test]
+    public void Contains_WhenSameCenterOuterLarger_ReturnsTrue()
+    {
+        Bounds inner = new Bounds(new Vector3(0, 0, 0), new Vector3(2, 2, 2) );
+        Bounds outer = new Bounds(new Vector3(0, 0, 0), new Vector3(6, 6, 6) );
+        Assert.IsTrue(outer.Contains(inner));
+    }
+
+
+    [Test]
+    public void Contains_WhenSameCenterOuterSmaller_ReturnsTrue()
+    {
+        Bounds inner = new Bounds(new Vector3(0, 0, 0), new Vector3(2, 2, 2) );
+        Bounds outer = new Bounds(new Vector3(0, 0, 0), new Vector3(6, 6, 6) );
+        Assert.IsFalse(inner.Contains(outer));
+    }
+
+    [Test]
+    public void Contains_WhenTotallyDisjoint_ReturnsFalse()
+    {
+        Bounds inner = new Bounds(new Vector3(20, 20, 20), new Vector3(2, 2, 2) );
+        Bounds outer = new Bounds(new Vector3(0, 0, 0), new Vector3(6, 6, 6) );
+        Assert.IsFalse(inner.Contains(outer));
+    }
 }

--- a/WhosAGoodBoy/Who's A Good Boy/Assets/Scripts/FencedIn.cs
+++ b/WhosAGoodBoy/Who's A Good Boy/Assets/Scripts/FencedIn.cs
@@ -21,7 +21,7 @@ public class FencedIn : MonoBehaviour {
 
     private void Update()
     {
-        NotifySubscribers();
+        CheckOutOfBoundsState();
     }
 
     private void OnDrawGizmos()
@@ -35,16 +35,28 @@ public class FencedIn : MonoBehaviour {
         Gizmos.DrawWireCube(FencedBound.center, FencedBound.size);
     }
 
-    private void NotifySubscribers()
+    private void CheckOutOfBoundsState()
     {
         bool outOfBounds = !IsInBounds();
 
-        if (_previouslyOutOfBounds && !outOfBounds) {
-            FireBackInBoundsEvent();
-            _previouslyOutOfBounds = false;
+        if (outOfBounds) {
+            HandleOutOfBounds();
             return;
         }
 
+        if (_previouslyOutOfBounds) {
+            HandleBackInBounds();
+        }
+    }
+
+    private void HandleBackInBounds()
+    {
+        FireBackInBoundsEvent();
+        _previouslyOutOfBounds = false;
+    }
+
+    private void HandleOutOfBounds()
+    {
         FireOutOfBoundsEvent();
         _previouslyOutOfBounds = true;
     }


### PR DESCRIPTION
- FencedIn has to send out of bounds events every frame that it's out of bounds to handle the "corner case" (lol) where a character slides down one edge to a corner. i.e. they go out of bounds in one dimension and then another dimension
- Added tests for bounds.Contains
- Edited main camerarig to have a large z extant on the camera fence so that it always contained the camera bounds in the z dimension